### PR TITLE
Fix level record

### DIFF
--- a/src/components/level/LevelItem.tsx
+++ b/src/components/level/LevelItem.tsx
@@ -1,11 +1,9 @@
 'use client';
 
-import {ILevel} from 'interfaces/level-interface';
+import {ILevelWithUserRecord} from 'interfaces/level-interface';
 import styled from 'styled-components';
 import {useRouter} from 'next/navigation';
 import Trophy from 'components/level/Trophy';
-import {useContext} from 'react';
-import {LevelContext} from '../../store/LevelContext';
 
 const Container = styled.div`
   display: flex;
@@ -30,13 +28,11 @@ const LevelSubTitle = styled.div`
 `;
 
 interface IProps {
-  levelData: ILevel;
+  levelData: ILevelWithUserRecord;
 }
 
 function LevelItem({levelData}: IProps): JSX.Element {
   const router = useRouter();
-  const store = useContext(LevelContext);
-  const trophy = store.getUserLevelRecord(levelData.id);
 
   // todo: store.getLevelRecord 실행 전에 store.getUserLevelRecord 먼저 작동함.
   // todo: store.levelRecord 갱신 후 store.getUserLevelRecord 작동하도록 수정해야 함.
@@ -46,13 +42,13 @@ function LevelItem({levelData}: IProps): JSX.Element {
     setTrophy(store.getUserLevelRecord(levelData.id));
   }, [store.levelRecord]); */
 
-  const onClickLevelItem = (level: ILevel): void => {
+  const onClickLevelItem = (level: ILevelWithUserRecord): void => {
     router.push(`/levels/${level.id}`);
   };
 
   return (
     <Container onClick={() => onClickLevelItem(levelData)}>
-      <Trophy trophy={trophy} />
+      <Trophy trophy={levelData.userRecord?.trophy} />
       <LevelInfo>
         <LevelNum>00</LevelNum>
         <LevelTitle>{levelData.title}</LevelTitle>

--- a/src/components/level/LevelList.tsx
+++ b/src/components/level/LevelList.tsx
@@ -1,9 +1,11 @@
 'use client';
 
-import {ILevel, ILevelInfo} from 'interfaces/level-interface';
-import {useRouter} from 'next/navigation';
+import {ILevelInfo, ILevelWithUserRecord} from 'interfaces/level-interface';
 import styled from 'styled-components';
+import {useContext, useEffect} from 'react';
+import {observer} from 'mobx-react-lite';
 import LevelItem from './LevelItem';
+import {LevelContext} from '../../store/LevelContext';
 
 const Container = styled.div`
   display: flex;
@@ -20,14 +22,28 @@ interface IProps {
 }
 
 function LevelList({levelList}: IProps): JSX.Element | null {
+  const store = useContext(LevelContext);
+
+  useEffect(() => {
+    levelList.levels.forEach((level: ILevelWithUserRecord) => {
+      const result = store.getUserLevelRecord(level.id);
+      if (result) {
+        level.userRecord = result;
+        // TODO: level의 변화를 감지하지 못해 리렌더링 작동 X.
+        // react dev tools로 확인 시 LevelItem의 props는 변화함. 리렌더링 X.
+        // trophy의 props 변화 X, 리렌더링 X.
+      }
+    });
+  }, [levelList, store.levelRecord]);
+
   return (
     <Container>
       <GroupTitle>{levelList.title}</GroupTitle>
-      {levelList.levels.map((level: ILevel) => (
+      {levelList.levels.map((level: ILevelWithUserRecord) => (
         <LevelItem levelData={level} key={level.id} />
       ))}
     </Container>
   );
 }
 
-export default LevelList;
+export default observer(LevelList);

--- a/src/components/level/Trophy.tsx
+++ b/src/components/level/Trophy.tsx
@@ -4,7 +4,7 @@ type IProps = {
   /**
    * 0 ~ 3, -99(기록이 없는 경우),
    */
-  trophy: number;
+  trophy: number | undefined;
 };
 
 const Container = styled.svg<{$trophy: number}>`
@@ -12,7 +12,7 @@ const Container = styled.svg<{$trophy: number}>`
   ${(props) => (props.$trophy === -99 ? 'filter: grayscale(100%); opacity: 0.3;' : '')}
 `;
 
-function Trophy({trophy}: IProps): JSX.Element {
+function Trophy({trophy = -99}: IProps): JSX.Element {
   return (
     <Container
       $trophy={trophy}

--- a/src/interfaces/level-interface.ts
+++ b/src/interfaces/level-interface.ts
@@ -34,6 +34,10 @@ export interface ILevel {
   order: number;
 }
 
+export interface ILevelWithUserRecord extends ILevel {
+  userRecord?: IUserTypingData;
+}
+
 export interface ILevelListParams {
   categoryId?: string;
   orderBy?: string;
@@ -82,6 +86,7 @@ export interface IUserTypingData extends IScoreData {
   id: string;
   userId: string | null | undefined;
   levelId: string;
+  categoryId: string;
   keyInputList: IKeyInput[];
   createdAt: Timestamp | null;
 }

--- a/src/store/LevelContext.tsx
+++ b/src/store/LevelContext.tsx
@@ -32,7 +32,8 @@ export interface ILevelContext {
   saveUserTypingData(userTypingData: IUserTypingData): void;
 
   getLevelRecord(uid: string | null): void;
-  getUserLevelRecord(levelId: string): number;
+  // getUserLevelRecord(levelId: string): number;
+  getUserLevelRecord(levelId: string): IUserTypingData | undefined;
 }
 
 const defaultState: ILevelContext = {
@@ -183,11 +184,20 @@ const defaultState: ILevelContext = {
    * 이 숫자를 이용해 트로피 별을 표시하며, 기록이 없을 땐 -99로 표기.
    * @param levelId
    */
-  getUserLevelRecord(levelId: string) {
+  /* getUserLevelRecord(levelId: string) {
     const result = this.levelRecord?.find((record) => {
       return record.levelId === levelId;
     });
     return result ? result.trophy : -99;
+  }, */
+
+  /**
+   * 해당 레벨의 기록을 가져옴.
+   */
+  getUserLevelRecord(levelId: string) {
+    return this.levelRecord?.find((record) => {
+      return record.levelId === levelId;
+    });
   }
 };
 


### PR DESCRIPTION
1. 인터페이스 추가.
2. 트로피 개수 뿐만 아니라 모든 `userTypingData`를 가져오도록 수정.
3. `levelData`와 `userRecord`를 `LevelList`에서 합침.
4. props의 형에 undefined 추가 및 기본 값 설정.

**TODO: userTypingData collection에 사용자 별 collection 추가.**